### PR TITLE
Added more details on installing the project with example .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+PORT=5000
+NODE_ENV="development"
+JWT_SECRET="keyboard_cat"
+
+# Database
+DATABASE_NAME="pensieve"
+DATABASE_HOST="localhost"
+DATABASE_PORT=27017
+MONGODB_URI="mongodb://localhost:27017/pensieve"
+
+# SendGrid setup
+SENDGRID_API_KEY="APIKeyGoesHere"
+ADMIN_EMAIL="email@example.com"

--- a/README.md
+++ b/README.md
@@ -6,14 +6,50 @@
 
 This project contains the backend for Pensieve providing the API for accessing data using NodeJS and MongoDB.
 
-## Installing
+## Getting Started
+
+### Dependencies
+
+- Node 4+
+- MongoDB
+- SendGrid
+
+### Installing
 
 Clone this project and update path accordingly:
 
 ```sh
-$ git clone git@github.com:pensieve-srs/pensieve-api.git
-$ cd pensieve-api/
+git clone git@github.com:pensieve-srs/pensieve-api.git
+cd pensieve-api/
 ```
+
+Install the dependencies:
+
+```sh
+yarn install
+```
+
+Copy the `.env.example` and update the variables to your settings:
+
+```sh
+cp .env.example .env.development.local
+```
+
+Start MongoDB instance:
+
+```sh
+mongod
+```
+
+Finally, start the server and watch for changes:
+
+```sh
+yarn run start:watch
+```
+
+Open up your browser and navigate to
+[http://localhost:5000/docs/](http://localhost:5000/docs/). You should see a
+Swagger API Docs interface.
 
 ## Contributing
 


### PR DESCRIPTION
I added a few more detailed instructions on installing the project. I removed the `$` so it's easier to copy/paste from the code snippets. I also added a `.env.example` file so it's clearer on what local `.env` variables need to be set.