### PR TITLE
Fix reset and delete actions

### DIFF
--- a/src/controllers/cards.js
+++ b/src/controllers/cards.js
@@ -76,7 +76,7 @@ module.exports.updateCard = async (req, res, next) => {
     await Joi.validate(req, cardSchemas.updateCard, { allowUnknown: true });
 
     const { front, back, notes } = req.body;
-    const card = await Card.update(id, { front, back, notes }, req.user);
+    const card = await Card.updateCard(id, { front, back, notes }, req.user);
     // eslint-disable-next-line no-param-reassign
     card.recallRate = getRecallRate(card);
     res.send(card);

--- a/src/controllers/decks.js
+++ b/src/controllers/decks.js
@@ -70,7 +70,7 @@ module.exports.updateDeck = async (req, res, next) => {
     await Joi.validate(req, deckSchemas.updateDeck, { allowUnknown: true });
 
     const { title, description, notes, tags } = req.body;
-    const deck = await Deck.update(id, { title, description, notes, tags }, req.user);
+    const deck = await Deck.updateDeck(id, { title, description, notes, tags }, req.user);
 
     res.send(deck);
   } catch (err) {
@@ -95,6 +95,7 @@ module.exports.deleteDeck = async (req, res, next) => {
 module.exports.resetDeck = async (req, res, next) => {
   try {
     const { id } = req.params;
+
     await Joi.validate(req, deckSchemas.resetDeck, { allowUnknown: true });
 
     await Card.resetAllByDeck(id, req.user);

--- a/src/models/card.js
+++ b/src/models/card.js
@@ -55,7 +55,7 @@ class CardClass {
       .lt(new Date());
   }
 
-  static update(id, body, user) {
+  static updateCard(id, body, user) {
     const { front, back, notes } = body;
     return this.findOneAndUpdate({ _id: id, user }, removeEmpty({ front, back, notes }), {
       new: true,

--- a/src/models/deck.js
+++ b/src/models/deck.js
@@ -31,7 +31,7 @@ class DeckClass {
     });
   }
 
-  static update(id, body, user) {
+  static updateDeck(id, body, user) {
     return this.findOneAndUpdate(
       { _id: id, user },
       removeEmpty({

--- a/test/api/models/cards.js
+++ b/test/api/models/cards.js
@@ -16,7 +16,7 @@ describe('Card model', () => {
   describe('update', () => {
     it('should update single card for user', async () => {
       const newCard = { front: 'New card front', back: 'New card back' };
-      const card = await Card.update(cards[0]._id, newCard, user1);
+      const card = await Card.updateCard(cards[0]._id, newCard, user1);
       expect(card.front).to.equal(newCard.front);
       expect(card.back).to.equal(newCard.back);
     });

--- a/test/api/models/decks.js
+++ b/test/api/models/decks.js
@@ -18,14 +18,14 @@ describe('Deck model', () => {
   describe('update', () => {
     it('should update single deck for user', async () => {
       const newDeck = { title: 'New deck', description: 'New description' };
-      const deck = await Deck.update(deck1._id, newDeck, user1._id);
+      const deck = await Deck.updateDeck(deck1._id, newDeck, user1._id);
       expect(deck.title).to.equal(newDeck.title);
       expect(deck.description).to.equal(newDeck.description);
       expect(deck.user).to.deep.equal(user1._id);
     });
     it('should not update fields that are not defined', async () => {
       const newDeck = { title: 'New deck', description: undefined };
-      const deck = await Deck.update(deck1._id, newDeck, user1._id);
+      const deck = await Deck.updateDeck(deck1._id, newDeck, user1._id);
       expect(deck.description).to.be.ok;
     });
   });


### PR DESCRIPTION
### Description
There were naming conflicts between the mongoose interface and the model methods that caused issues when deleting/reseting.