### PR TITLE
Simple fix for slow tests on Windows. Use ipv4 by default, bypassing …

### DIFF
--- a/mongoose/config/database.js
+++ b/mongoose/config/database.js
@@ -5,7 +5,7 @@ const config = require('../../config');
 
 module.exports.connect = () => {
   mongoose.Promise = global.Promise;
-  mongoose.connect(config.database.uri);
+  mongoose.connect(config.database.uri, { family: 4 });
 
   const mongoDB = mongoose.connection;
 


### PR DESCRIPTION
…ipv6 attempt.

Fixes #62 